### PR TITLE
✨ feat :  interview 페이지 작업완료

### DIFF
--- a/client/src/components/common/Button.tsx
+++ b/client/src/components/common/Button.tsx
@@ -12,11 +12,17 @@ export interface BtnStyledProps {
 export interface ButtonProps extends BtnStyledProps {
   onClick: () => void;
   value: string;
+  disabled?: boolean;
 }
 
-const Button = ({ onClick, value, btnType = 'MAIN', ...cssProPerty }: ButtonProps) => {
+const Button = ({ onClick, value, btnType = 'MAIN', disabled, ...cssProPerty }: ButtonProps) => {
   return (
-    <S.Button onClick={onClick} btnType={btnType} {...cssProPerty}>
+    <S.Button
+      onClick={onClick}
+      btnType={btnType}
+      disabled={disabled ? true : false}
+      {...cssProPerty}
+    >
       {btnType === 'LOGIN' && <img src={githubLogo} />}
       {value}
     </S.Button>

--- a/client/src/components/interviewPage/InterviewContainer.style.ts
+++ b/client/src/components/interviewPage/InterviewContainer.style.ts
@@ -17,13 +17,15 @@ const QuestionWrapper = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 5px;
+    gap: 10px;
     font-weight: 500;
     > h1 {
       font-size: ${theme.font.xxl};
     }
     > h2 {
       font-size: ${theme.font.xl};
+      word-break: keep-all;
+      text-align: center;
     }
   `}
 `;
@@ -37,4 +39,22 @@ const InterviewInput = styled.textarea`
   overflow: auto;
 `;
 
-export { Container, QuestionWrapper, InterviewInput };
+const TypingLimitContainer = styled.div<{ warningSign: boolean }>`
+  width: 100%;
+  text-align: end;
+  color: ${({ warningSign }) => warningSign && 'red'};
+  ${({ warningSign }) =>
+    warningSign &&
+    `
+    animation : warning 0.1s alternate;
+    @keyframes warning{
+      from {
+        transform: rotate(1deg);
+      }
+      to {
+        transform: rotate(-1deg);
+      }}
+    `}
+`;
+
+export { Container, QuestionWrapper, InterviewInput, TypingLimitContainer };

--- a/client/src/components/interviewPage/InterviewContainer.tsx
+++ b/client/src/components/interviewPage/InterviewContainer.tsx
@@ -1,12 +1,16 @@
 import { useRef, useState } from 'react';
 import Button from '../common/Button';
 import * as S from './InterviewContainer.style';
-import useSubmitAnswer from '../../hooks/useSubmitAnswer';
+
 import Loading from '../common/Loading';
 import TimerContainer from './TimerContainer';
+import { UseMutateFunction } from '@tanstack/react-query';
+import { AiCheckAnswerType, SubmitData } from '../../hooks/useSubmitAnswer';
 
-interface InterViewData {
+interface InterViewContainerProps {
   data: string[];
+  mutate: UseMutateFunction<AiCheckAnswerType, unknown, SubmitData[], unknown>;
+  mutateLoading: boolean;
 }
 
 interface Answer {
@@ -16,12 +20,11 @@ interface Answer {
 
 const MAX_ANSWER_LENGTH = 300;
 
-const InterviewContainer = ({ data }: InterViewData) => {
+const InterviewContainer = ({ data, mutate, mutateLoading }: InterViewContainerProps) => {
   const ref = useRef<HTMLTextAreaElement | null>(null);
   const [questionIdx, setQuestionIdx] = useState(1);
   const [answers, setAnswers] = useState<Answer[]>([]);
   const [typingLength, setTypingLength] = useState(0);
-  const { mutate, isLoading } = useSubmitAnswer();
 
   const totalQuestionCount = data.length;
   const isLastQuestion = questionIdx === totalQuestionCount;
@@ -58,8 +61,8 @@ const InterviewContainer = ({ data }: InterViewData) => {
       mutate(allAnswer);
     }
   };
-  console.log(answers);
-  if (isLoading) {
+
+  if (mutateLoading) {
     return <Loading />;
   }
 

--- a/client/src/components/interviewPage/TimerContainer.stlye.ts
+++ b/client/src/components/interviewPage/TimerContainer.stlye.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+const TimerContainer = styled.div<{ warningAlert: boolean }>`
+  ${({ warningAlert }) =>
+    warningAlert &&
+    `
+      color : red;
+      animation : warning 1s infinite;
+      @keyframes warning{
+        0% {
+          transform: rotate(2deg);
+        }
+
+        50% {
+          transform : rotate(-2deg);
+        }
+
+        100% {
+          transform: rotate(0deg);
+        }
+
+      }
+  `}
+`;
+
+export { TimerContainer };

--- a/client/src/components/interviewPage/TimerContainer.tsx
+++ b/client/src/components/interviewPage/TimerContainer.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import * as S from './TimerContainer.stlye';
+const BASETIME = 15;
+
+interface TimerProps {
+  currentQuestion: number;
+  isLastQuestion: boolean;
+  moveToNextQuestion: () => void;
+  onSubmitAnswer: () => void;
+}
+
+const TimerContainer = ({
+  currentQuestion,
+  isLastQuestion,
+  moveToNextQuestion,
+  onSubmitAnswer,
+}: TimerProps) => {
+  const [time, setTime] = useState(BASETIME);
+
+  const getSeconds = (time: number) => {
+    const seconds = time % 60;
+    if (seconds < 10) {
+      return '0' + String(seconds);
+    } else {
+      return String(seconds);
+    }
+  };
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      if (time >= 0) {
+        setTime((prev) => prev - 1);
+      }
+    }, 1000);
+
+    if (time < 0) {
+      // 다음 단계 or 제출 후 다음 재설정
+      if (isLastQuestion) {
+        onSubmitAnswer();
+      } else {
+        moveToNextQuestion();
+        setTime(BASETIME);
+      }
+    }
+
+    return () => clearInterval(timer);
+  }, [time]);
+
+  //  문제가 넘어가면 time 세팅
+  useEffect(() => {
+    setTime(BASETIME);
+  }, [currentQuestion]);
+
+  return (
+    <S.TimerContainer warningAlert={time <= 10 ? true : false}>
+      {Math.floor(+(time / 60))} : {getSeconds(time)}
+    </S.TimerContainer>
+  );
+};
+
+export default TimerContainer;

--- a/client/src/components/interviewPage/TimerContainer.tsx
+++ b/client/src/components/interviewPage/TimerContainer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import * as S from './TimerContainer.stlye';
-const BASETIME = 15;
+const BASETIME = 180;
 
 interface TimerProps {
   currentQuestion: number;

--- a/client/src/components/myPage/AnswerDetailModal.tsx
+++ b/client/src/components/myPage/AnswerDetailModal.tsx
@@ -29,7 +29,7 @@ const AnswerDetailModal = ({ questionId, changeModalState }: AnswerDetailModalPr
   const navigate = useNavigate();
 
   const moveToQuestionId = () => {
-    navigate(`/interview?edit=${questionId}`);
+    navigate(`/interview/${questionId}`);
   };
 
   const handler = (e: MouseEvent) => {

--- a/client/src/components/myPage/Profile.tsx
+++ b/client/src/components/myPage/Profile.tsx
@@ -19,7 +19,7 @@ const Profile = ({ avatar_url, nickName, todayQACnt, alldayQACnt }: UserProfileP
       count: todayQACnt,
     },
     {
-      description: '오늘의 답변',
+      description: '모든 답변',
       count: alldayQACnt,
     },
   ];

--- a/client/src/functions/checkInterviewParams.ts
+++ b/client/src/functions/checkInterviewParams.ts
@@ -1,8 +1,8 @@
 import { URLSearchParams } from 'url';
 
-const checkInterviewParams = (searchParams: URLSearchParams) => {
+const checkInterviewParams = (searchParams: URLSearchParams, findQuery: string) => {
   // 만약 Params가 존재한다면 number Type으로 변경
-  const getParams = ['edit', 'stacks'].map((value) => searchParams.get(value));
+  const getParams = searchParams.get(findQuery);
 
   return getParams;
 };

--- a/client/src/hooks/useGetDetailAnswer.ts
+++ b/client/src/hooks/useGetDetailAnswer.ts
@@ -18,7 +18,7 @@ const getDetailAnswer = async (id: number | string): Promise<Questions> => {
 };
 
 const useGetDetailAnswer = (id: number | string) => {
-  const { data, isLoading } = useQuery([queryKey.detailQA, id], () => getDetailAnswer(id));
+  const { data, isLoading } = useQuery([queryKey.detailQA, +id], () => getDetailAnswer(id));
   return { data, isLoading };
 };
 

--- a/client/src/hooks/useGetInterview.ts
+++ b/client/src/hooks/useGetInterview.ts
@@ -8,14 +8,21 @@ const getInterView = async (stacks: string): Promise<string[]> => {
   return data;
 };
 
+const ONEMIN = 60000;
+// 3분 * 문제 수 * 여유시간(1분)=> 1000*180*stacks.length +60000
 const useGetInterview = (stacks: string) => {
+  const getStacksCount = stacks.split(',').length;
+  const getQuestionsCount = getStacksCount >= 5 ? getStacksCount : 5;
+
   const { data = [], isLoading } = useQuery(
     [queryKey.getInterviews, stacks],
     () => getInterView(stacks),
     {
       keepPreviousData: true,
+      staleTime: ONEMIN * 3 * getQuestionsCount + ONEMIN,
+      cacheTime: ONEMIN * 3 * getQuestionsCount * 1.5,
     },
-  ); // 인터뷰 쿼리 실행
+  );
   return { data, isLoading };
 };
 

--- a/client/src/hooks/useGetInterview.ts
+++ b/client/src/hooks/useGetInterview.ts
@@ -9,7 +9,7 @@ const getInterView = async (stacks: string): Promise<string[]> => {
 };
 
 const useGetInterview = (stacks: string) => {
-  const { data, isLoading } = useQuery(
+  const { data = [], isLoading } = useQuery(
     [queryKey.getInterviews, stacks],
     () => getInterView(stacks),
     {

--- a/client/src/hooks/usePreviewAnwser.ts
+++ b/client/src/hooks/usePreviewAnwser.ts
@@ -28,7 +28,9 @@ const getPreviewAnswers = async (page: number): Promise<PreviewAnswer> => {
 };
 
 const usePreviewAnwser = (page: number) => {
-  const { data, isLoading } = useQuery([queryKey.userInfo, page], () => getPreviewAnswers(page));
+  const { data, isLoading } = useQuery([queryKey.userQAPreview, page], () =>
+    getPreviewAnswers(page),
+  );
   return { data, isLoading };
 };
 export default usePreviewAnwser;

--- a/client/src/hooks/useReplytoQuestion.ts
+++ b/client/src/hooks/useReplytoQuestion.ts
@@ -1,0 +1,40 @@
+import { AiCheckAnswerType } from './useSubmitAnswer';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import Api from '../apis';
+import queryKey from '../react-query/queryKey';
+
+interface ReplyType {
+  answer: string;
+  question: string;
+}
+
+const replyToQuestion = async (replyAnswer: ReplyType, id: string): Promise<AiCheckAnswerType> => {
+  const successData: AiCheckAnswerType = await Api.post(`user/editQuestion/${id}`, {
+    data: replyAnswer,
+  });
+  return successData;
+};
+
+const useReplytoQuestion = (id: string) => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { mutate, isLoading } = useMutation(
+    (replyAnswers: ReplyType[]) => {
+      const replyData = replyAnswers[0];
+      return replyToQuestion(replyData, id);
+    },
+    {
+      onSuccess: (data) => {
+        queryClient.invalidateQueries([queryKey.userInfo]);
+        queryClient.invalidateQueries([queryKey.detailQA, +id]);
+        queryClient.setQueryData([queryKey.answer], data.data);
+        navigate('/result');
+      },
+    },
+  );
+  return { mutate, isLoading };
+};
+
+export default useReplytoQuestion;

--- a/client/src/hooks/useSubmitAnswer.ts
+++ b/client/src/hooks/useSubmitAnswer.ts
@@ -39,7 +39,8 @@ const useSubmitAnswer = (): UseSubmitType => {
     {
       onSuccess: (data) => {
         // userInfo, preview, detailQa
-        queryClient.invalidateQueries([queryKey.userInfo, queryKey.userQAPreview]);
+        queryClient.invalidateQueries([queryKey.userInfo]);
+        queryClient.invalidateQueries([queryKey.userQAPreview]);
         queryClient.removeQueries([queryKey.getInterviews]);
         queryClient.setQueryData([queryKey.answer], data.data);
         navigate('/result');

--- a/client/src/hooks/useSubmitAnswer.ts
+++ b/client/src/hooks/useSubmitAnswer.ts
@@ -1,10 +1,9 @@
-import { AxiosResponse } from 'axios';
 import { UseMutateFunction, useMutation, useQueryClient } from '@tanstack/react-query';
 import Api from '../apis';
 import { useNavigate } from 'react-router-dom';
 import queryKey from '../react-query/queryKey';
 
-interface SubmitData {
+export interface SubmitData {
   answer: string;
   question: string;
 }
@@ -15,17 +14,19 @@ interface SuccessData {
   aiAnswer: string;
 }
 
-interface AxiosResType {
+export interface AiCheckAnswerType {
   data: SuccessData[];
 }
 
 interface UseSubmitType {
-  mutate: UseMutateFunction<AxiosResType, unknown, SubmitData[], unknown>;
+  mutate: UseMutateFunction<AiCheckAnswerType, unknown, SubmitData[], unknown>;
   isLoading: boolean;
 }
 
-const submitAnswer = async (submitData: SubmitData[]): Promise<AxiosResType> => {
-  const successData: AxiosResType = await Api.post('/user/editQuestions', { data: submitData });
+const submitAnswer = async (submitData: SubmitData[]): Promise<AiCheckAnswerType> => {
+  const successData: AiCheckAnswerType = await Api.post('/user/editQuestions', {
+    data: submitData,
+  });
   return successData;
 };
 
@@ -38,7 +39,7 @@ const useSubmitAnswer = (): UseSubmitType => {
     {
       onSuccess: (data) => {
         // userInfo, preview, detailQa
-        queryClient.invalidateQueries([queryKey.userInfo, queryKey.userQA]);
+        queryClient.invalidateQueries([queryKey.userInfo, queryKey.userQAPreview]);
         queryClient.removeQueries([queryKey.getInterviews]);
         queryClient.setQueryData([queryKey.answer], data.data);
         navigate('/result');

--- a/client/src/hooks/useUser.ts
+++ b/client/src/hooks/useUser.ts
@@ -12,7 +12,7 @@ interface User {
 }
 
 interface UseUser {
-  user: User | null | undefined;
+  user: User | null;
   isLoading: boolean;
   isError: boolean;
 }
@@ -29,7 +29,7 @@ const getUser = async (): Promise<User | null> => {
 
 export default function useUser(): UseUser {
   const currentToken = localStorage.getItem('token');
-  const { data: user, isLoading, isError } = useQuery([queryKey.userInfo], getUser);
+  const { data: user = null, isLoading, isError } = useQuery([queryKey.userInfo], getUser);
 
   const queryClient = useQueryClient();
 

--- a/client/src/pages/Interview.tsx
+++ b/client/src/pages/Interview.tsx
@@ -3,24 +3,14 @@ import checkInterviewParams from '../functions/checkInterviewParams';
 import InterviewContainer from '../components/interviewPage/InterviewContainer';
 import useGetInterview from '../hooks/useGetInterview';
 import Loading from '../components/common/Loading';
-import { useEffect } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
-import queryKey from '../react-query/queryKey';
-// 수정 시 ?edit={editId} 값으로 받을 예정
-// 등록 시 ?stacks='react&react&react&react&' 값으로 받을 예정
-// 둘다 string 이라 생각하고 작업할 것 대신 edit 인지 stacks 인지의 여부의 따라 작업할 것.
 
 const Interview = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const [edit, stacks] = checkInterviewParams(searchParams);
+  const [searchParams] = useSearchParams();
+  const stacks = checkInterviewParams(searchParams, 'stacks');
 
   const { data, isLoading } = useGetInterview(stacks as string);
 
-  const queryClient = useQueryClient();
-
-  //  제출 버튼일 때와 제출 버튼이 아닐 때를 구분해야함. 함수와 버튼 내부 글자가 변경됨
-  // return {isLoading ? <Loading /> :<InterviewContainer />};
-  return <>{isLoading && !data ? <Loading /> : <InterviewContainer data={data as string[]} />}</>;
+  return <>{isLoading ? <Loading /> : <InterviewContainer data={data} />}</>;
 };
 
 export default Interview;

--- a/client/src/pages/Interview.tsx
+++ b/client/src/pages/Interview.tsx
@@ -3,14 +3,23 @@ import checkInterviewParams from '../functions/checkInterviewParams';
 import InterviewContainer from '../components/interviewPage/InterviewContainer';
 import useGetInterview from '../hooks/useGetInterview';
 import Loading from '../components/common/Loading';
+import useSubmitAnswer from '../hooks/useSubmitAnswer';
 
 const Interview = () => {
   const [searchParams] = useSearchParams();
   const stacks = checkInterviewParams(searchParams, 'stacks');
 
   const { data, isLoading } = useGetInterview(stacks as string);
-
-  return <>{isLoading ? <Loading /> : <InterviewContainer data={data} />}</>;
+  const { mutate, isLoading: mutateLoading } = useSubmitAnswer();
+  return (
+    <>
+      {isLoading ? (
+        <Loading />
+      ) : (
+        <InterviewContainer data={data} mutate={mutate} mutateLoading={mutateLoading} />
+      )}
+    </>
+  );
 };
 
 export default Interview;

--- a/client/src/pages/ReplyInterview.tsx
+++ b/client/src/pages/ReplyInterview.tsx
@@ -1,0 +1,25 @@
+import { useParams } from 'react-router-dom';
+import Loading from '../components/common/Loading';
+import useGetDetailAnswer from '../hooks/useGetDetailAnswer';
+import InterviewContainer from '../components/interviewPage/InterviewContainer';
+import useReplytoQuestion from '../hooks/useReplytoQuestion';
+
+const ReplyInterview = () => {
+  const { id = '' } = useParams();
+
+  const { data: detailData, isLoading } = useGetDetailAnswer(id);
+  const { mutate, isLoading: mutateLoading } = useReplytoQuestion(id);
+  const getQuestion = detailData ? [detailData.text] : [];
+
+  return (
+    <>
+      {isLoading ? (
+        <Loading />
+      ) : (
+        <InterviewContainer data={getQuestion} mutate={mutate} mutateLoading={mutateLoading} />
+      )}
+    </>
+  );
+};
+
+export default ReplyInterview;

--- a/client/src/react-query/queryKey.ts
+++ b/client/src/react-query/queryKey.ts
@@ -1,3 +1,9 @@
+// detailQA : 상세 모달
+// userInfo : 유저가 등록한 댓글 수
+// userQAPreview : 페이지네이션 관련
+// answer : AI 응답 데이터 결과물
+// getInterviews : ai 면접질문 가져오기
+
 const queryKey = {
   // 나중에 답변 제출 후 세가지를 모두 invalidateQueries로 무효화 시킬 것.
   userInfo: 'userInfo',

--- a/client/src/react-query/queryKey.ts
+++ b/client/src/react-query/queryKey.ts
@@ -1,7 +1,7 @@
 const queryKey = {
   // 나중에 답변 제출 후 세가지를 모두 invalidateQueries로 무효화 시킬 것.
   userInfo: 'userInfo',
-  userQA: 'answerPreview',
+  userQAPreview: 'answerPreview',
   detailQA: 'detailQA',
   getInterviews: 'getInterviews',
   answer: 'answer',

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -5,6 +5,7 @@ import Test from '../pages/Test';
 import MyPage from '../pages/MyPage';
 import Interview from '../pages/Interview';
 import Login from '../pages/Login';
+import ReplyInterview from '../pages/ReplyInterview';
 
 const Routes = () => {
   return (
@@ -14,6 +15,7 @@ const Routes = () => {
       <Route path="/result" element={<Result />} />
       <Route path="/myPage" element={<MyPage />} />
       <Route path="/interview" element={<Interview />} />
+      <Route path="/interview/:id" element={<ReplyInterview />} />
       <Route path="/login" element={<Login />} />
     </ReactRoutes>
   );


### PR DESCRIPTION
ui 관련
- common 버튼 disabled 속성 추가
- interviewPage 타이머, 문제풀이 갯수 컨테이너 제작 완료
    - 타이머 시간 초과 시 데이터 제출 -> 300자 넘을 시 300자로 유지
    - 시간 10초 전부터 제출 애니메이션 동작
- interviewPage 글자수 제한 관련 컨테이너 제작 완료

기능 관련
- checkInterviewParams 수정 -> 한정된 인자에서 단일 지정 인자로
- useGetinterview fallback 데이터 지정을 통해 추가 타입을 지정해주지 않아도 되도록 변경
- interview 질문 staleTime , cacheTime 개별 지정 -> 문제 수당 최대 3분으로 계산
- invalidateQueries 미숙으로 인한 이슈로 인한 queryKey 정리 => invalidateQueries 사용 시 ['key1','key2'] 로 지정시 두 조건을 만족해야 쿼리가 무효화 됨.
- interview 페이지 + 재 답변 페이지 공통 로직을 위한 작업 완료 mutate 함수 상위에서 받아오도록 지정 + 재 제출 관련 쿼리 작업 완료

버그 픽스
- userProfile 오타 수정 