### PR TITLE
🐛 fix : SearchInput 관련 에러 수정(후보군 filter, 입력 후 후보군 뜨지 않음), ✨ feat : 후보군 관련 통일 및 추가 함수 제작

### DIFF
--- a/client/src/components/mainPage/SearchInput.tsx
+++ b/client/src/components/mainPage/SearchInput.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useRecoilState } from 'recoil';
+import { SetterOrUpdater, useRecoilState } from 'recoil';
 
 import { stackState } from '../../states/mainPage';
 
@@ -15,25 +15,75 @@ interface stackForm {
 
 const SearchComponent = () => {
   // 검색 인풋 관련
-  const { register, handleSubmit, setValue } = useForm<stackForm>();
+  const { register, handleSubmit, setValue, watch } = useForm<stackForm>();
   const [stack, setStack] = useRecoilState(stackState);
 
   const handleValid = (newStack: stackForm) => {
-    if (!stack.includes(newStack.stack)) {
-      setStack((oldStacks) => [...oldStacks, newStack.stack]);
-    }
+    findOrSetStack(newStack.stack, stackList, stack, setStack, changeToUpperCase);
     setValue('stack', '');
     setOn(false);
+    blurFunc();
   };
 
   // 자동 완성 관련
   const [on, setOn] = useState(false);
-  const keywordSelect = (event: React.MouseEvent<HTMLLIElement>) => {
-    const newStack: stackForm = { stack: event.currentTarget.textContent || '' };
-    if (!stack.includes(newStack.stack)) {
-      setStack((oldStacks) => [...oldStacks, newStack.stack]);
+
+  // undefined일 수 있기에 빈 값으로 자동 할당
+  const inputValue = watch('stack') || '';
+
+  const keywordSelect = (event: React.MouseEvent<HTMLLIElement> | string) => {
+    typeof event === 'string'
+      ? findOrSetStack(event, stackList, stack, setStack, changeToUpperCase)
+      : findOrSetStack(
+          event.currentTarget.textContent || '',
+          stackList,
+          stack,
+          setStack,
+          changeToUpperCase,
+        );
+    // false로 선택되어있어  검색창이 지워지지도 않고, 키보드 입력값이 돌아가지 않습니다
+    // 만약 클릭 시 스택이 바로 선택되게 된다면 연관검색어 창을 꺼주고 값을 비워주는게 어떨까 합니다.
+    setOn(true);
+    setValue('stack', '');
+    blurFunc();
+  };
+
+  const findOrSetStack = (
+    typingStack: string, // 입력값(인풋창)
+    suggestions: string[], // 연관검색어 후보군
+    currentStacks: string[], // 현재 세팅된 Stacks
+    setStack: SetterOrUpdater<string[]>, // Stacks를 바꿀 상태
+    changeToUpperCase: (stack: string) => string, // 대문자 변환 함수
+  ) => {
+    // 사용자가 입력한 입력값 혹은 클릭한 입력값을 대문자로 변경
+    const upperCaseTypingStack = changeToUpperCase(typingStack);
+
+    // 현재 스택들과 입력값이 동일한게 있는 지 확인, 없다면 -1 반환
+    const findStackIdx = currentStacks
+      .map((stack) => stack.toUpperCase())
+      .indexOf(upperCaseTypingStack);
+
+    // 후보군을 전부 대문자화
+    const upperCaseSuggestions = suggestions.map((stack: string) => stack.toUpperCase());
+    // 후보군에 입력값이 있는 지 확인
+    const upperCaseSuggestIdx = upperCaseSuggestions.indexOf(upperCaseTypingStack);
+
+    // 현재 세팅된 스택에 input에 작성한 스택이 없고 후보군에는 있다면?
+    if (findStackIdx === -1 && upperCaseSuggestIdx > -1) {
+      setStack((oldStacks) => [...oldStacks, suggestions[upperCaseSuggestIdx]]);
+    } else if (findStackIdx === -1 && upperCaseSuggestIdx === -1) {
+      // 후보군에도 존재하지 않는다면
+      setStack((oldStacks) => [...oldStacks, typingStack]);
     }
-    setOn(false);
+  };
+
+  const changeToUpperCase = (stack: string) => stack.toUpperCase();
+
+  const blurFunc = () => {
+    const activeElement = document.activeElement as HTMLElement;
+    if (activeElement) {
+      activeElement.blur();
+    }
   };
 
   return (
@@ -50,11 +100,28 @@ const SearchComponent = () => {
         </S.SearchButton>
       </S.SearchBox>
       <S.SuggestionKeywords visible={on}>
-        {stackList.map((el, index) => (
-          <S.SuggestionKeyword onMouseDown={keywordSelect} key={index} value={el}>
-            {el}
-          </S.SuggestionKeyword>
-        ))}
+        {inputValue.length > 0 ? (
+          <>
+            {stackList
+              .filter((stack: string) =>
+                changeToUpperCase(stack).includes(changeToUpperCase(inputValue)),
+              )
+              .map((matchedWord, idx) => (
+                <S.SuggestionKeyword onMouseDown={keywordSelect} key={idx} value={matchedWord}>
+                  {matchedWord}
+                </S.SuggestionKeyword>
+              ))}
+            <S.SuggestionKeyword onMouseDown={() => keywordSelect(inputValue)} value={inputValue}>
+              {inputValue}로 인터뷰하기
+            </S.SuggestionKeyword>
+          </>
+        ) : (
+          stackList.map((el, index) => (
+            <S.SuggestionKeyword onMouseDown={keywordSelect} key={index} value={el}>
+              {el}
+            </S.SuggestionKeyword>
+          ))
+        )}
       </S.SuggestionKeywords>
     </div>
   );


### PR DESCRIPTION
1. Stack 인풋창에 입력 시 연관 검색 관련 후보군이 줄어들지 않는 에러 발생
![searchInput_suggestionErr](https://github.com/For-The-Dev/Interview-Defence-Go-Client/assets/104412610/40a5d6bb-2fa4-4ead-85ce-ea5975dcfd8d)
1-1 해결 
filter와 삼항 연산자를 이용하여 해결. -> 아무것도 입력되지 않으면 전체 후보군 출력, 입력되었을 경우 대소문자를 전부 확인해서 연관 검색 후보군을 필터링 **(103번 줄 코드 확인 요)**
![searchInput_suggestionFin](https://github.com/For-The-Dev/Interview-Defence-Go-Client/assets/104412610/ce660bdc-318d-4a19-9436-0c1e912cf260)

2. Stack 입력값이 선택한 값과 동일하지만 대소문자로 인해 스택이 중복되는 문제 발생
![searchInput_sameStackErr](https://github.com/For-The-Dev/Interview-Defence-Go-Client/assets/104412610/0e722034-40fa-4a22-af00-e6f18c396350)
2-1 해결
로직 설명
    1. 기준 설정 (대문자 치환) : 입력 값, 연관 검색어 관련 후보 스택, 현재 선택한 스택 
    2. 조건문 설정 
        2-1. 입력 값이 연관검색어에 존재하고, 현재 선택한 스택에 존재않는다면? => 연관 검색어에 존재하는 단어로 스택에 추가
        ( 연관 검색어 ui에 선택됨으로 표시될 수 있도록 하기 위함)
        2-2. 입력 값이 연관검색어에 존재하지 않고, 현재 선택한 스택에 존재하지 않는다면 => 선택한 스택을 추가
        2-3.  현재 선택한 스택에 존재한다면 -> 아무 동작도 취하지 않음
    3. 위 항목들이 반복되어 함수를 제작하여 재사용 할 수 있도록 변경하였습니다.**(findOrSetStack, 51번째 줄 확인 요)**
![searchInput_sameStackFin](https://github.com/For-The-Dev/Interview-Defence-Go-Client/assets/104412610/c708f2c5-27a5-479c-8e85-bc3e8ffe4569)

3. Stack 선택 이후 Focus가 유지되어 연관 검색 관련 후보군이 표시되지 않는 문제 발생
![searchInput_focusErr](https://github.com/For-The-Dev/Interview-Defence-Go-Client/assets/104412610/ba6b9bc9-bf00-4587-8499-a4590eb86761)

3-1 해결
- Focus를 취소하는 blurFunc 제작하여, 선택 이후 Focus가 해지되도록 동작 추가**(blurFunc, 82번째 줄 확인 요)**
![searchInput_focusFin](https://github.com/For-The-Dev/Interview-Defence-Go-Client/assets/104412610/e95dccb4-35d5-4860-bcfa-3891ae84214c)

4. 사용자가 후보군에 없는 Stack 입력 시 연관 검색 후보군엔 도움말이 표시되지 않아 `'입력한 스택'으로 시작하기` 라는 항목 추가