### PR TITLE
🐛 fix : Date 관련 utc로 변경 -> 데이터베이스 시간 때문에 utc 00:00 기준 ) 이슈 

### DIFF
--- a/client/src/components/myPage/answerPreviewComponent/Content.tsx
+++ b/client/src/components/myPage/answerPreviewComponent/Content.tsx
@@ -1,6 +1,6 @@
 import * as S from './Content.style';
-import dayjs from 'dayjs';
 import arrowIcon from '../../../asset/images/arrow.png';
+import setTimeToZ from '../../../functions/setTimeToZ';
 
 interface ContentProps {
   createdAt: string;
@@ -11,7 +11,7 @@ interface ContentProps {
 }
 
 const Content = ({ createdAt, question, answer, id, changeModalState }: ContentProps) => {
-  const editQuestionDate = dayjs(createdAt).format('YYYY-MM-DD');
+  const editQuestionDate = setTimeToZ(createdAt);
 
   return (
     <S.QuestionWrapper>

--- a/client/src/components/myPage/modalComponent/AnswerBox.tsx
+++ b/client/src/components/myPage/modalComponent/AnswerBox.tsx
@@ -1,5 +1,5 @@
+import setTimeToZ from '../../../functions/setTimeToZ';
 import * as S from './AnswerBox.style';
-import dayjs from 'dayjs';
 
 interface AnswerType {
   text: string;
@@ -14,7 +14,7 @@ interface AnswerBoxProps {
 
 const AnswerBox = ({ answer }: AnswerBoxProps) => {
   const { createdAt } = answer;
-  const date = dayjs(createdAt).format('YYYY-MM-DD');
+  const date = setTimeToZ(createdAt);
   return (
     <S.AnswerWrapper>
       <S.Date>{date}</S.Date>

--- a/client/src/functions/setTimeToZ.ts
+++ b/client/src/functions/setTimeToZ.ts
@@ -1,0 +1,10 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(utc);
+
+export default function setTimeToZ(timeStr: string) {
+  const timeObj = dayjs(timeStr).utc().format('YYYY-MM-DD');
+
+  return timeObj;
+}


### PR DESCRIPTION
문제 
1. 서버 측 데이터베이스의 시간이 UTC 00:00 으로 세팅되어 있어, day.js를 사용하면 createdAt은 클라이언트 국가 기준으로 하지만,
프로필에 오늘의 답변수와 총 답변수 카운팅에 에러가 발생하는 것을 확인했습니다
- sqlite의 경우에는 데이터가 저장되는 시간을 변경할 수 있는 옵션(TimeZone)을 제공하지 않아 UTC 시간을 + 9시간 을 해주었습니다.
- 따라서 클라이언트에서도 utc 기준으로 데이터를 출력해야되기 utc 기준으로 한 dayjs 함수를 제작하고, 적용하였습니다.
16일에 작성한 댓글인데 아래와 같이 표시되는 문제가 발생했습니다.
<img width="300" alt="스크린샷 2023-05-16 오후 9 33 51" src="https://github.com/For-The-Dev/Interview-Defence-Go-Client/assets/104412610/31bd80ab-5363-4f46-8875-c7d4fbeaa959">
