### PR TITLE
✨ feat : 인증에 따른 라우터 분리 작업 완료

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,11 +6,9 @@ import { lightTheme, defalutTheme } from './styles/theme';
 import { modeState } from './states';
 import Layout from './pages/Layout';
 import Routes from './routes';
-import useUser from './hooks/useUser';
 
 function App() {
   const currentMode = useRecoilValue(modeState);
-  const { user } = useUser();
 
   return (
     <ThemeProvider theme={currentMode ? defalutTheme : lightTheme}>

--- a/client/src/pages/LoginPage.tsx
+++ b/client/src/pages/LoginPage.tsx
@@ -9,8 +9,8 @@ const LoginPage = () => {
   useEffect(() => {
     if (token) {
       localStorage.setItem('token', token);
-      navigate('/');
     }
+    navigate('/');
   }, []);
 
   return <div>Login...</div>;

--- a/client/src/pages/MyPage.tsx
+++ b/client/src/pages/MyPage.tsx
@@ -1,10 +1,9 @@
 import styled from 'styled-components';
 import Profile from '../components/myPage/Profile';
 import AnswersPreview from '../components/myPage/AnswersPreview';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import AnswerDetailModal from '../components/myPage/AnswerDetailModal';
 import useUser from '../hooks/useUser';
-import { useNavigate } from 'react-router-dom';
 
 const PageContainer = styled.div`
   height: 100%;
@@ -20,11 +19,6 @@ const MyPage = () => {
   const [modalState, setModalState] = useState(false);
 
   const { user } = useUser();
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    if (!user) navigate('/');
-  }, [user]);
 
   const changeModalState = (id?: number) => {
     // id가 전달되면 모달을 세팅, 전달되지 않으면 모달을 close

--- a/client/src/routes/NotFound.tsx
+++ b/client/src/routes/NotFound.tsx
@@ -1,0 +1,5 @@
+import { Navigate } from 'react-router-dom';
+
+export default function NotFound() {
+  return <Navigate to="/" />;
+}

--- a/client/src/routes/PrivateRoute.tsx
+++ b/client/src/routes/PrivateRoute.tsx
@@ -1,0 +1,15 @@
+import { ReactElement } from 'react';
+// Outlet은 중첩된 구조에서 사용되는 컴포넌트, 중첩 구조에서 하위 라우트를 렌더링하는 역할을 함
+import { Navigate, Outlet } from 'react-router-dom';
+
+interface PrivateRouteProps {
+  children?: ReactElement; // Private Route가 감싸고 있는 Component Element
+  authentication: boolean; // true여야 하위 컴포넌트 라우트로 이동시킴
+}
+
+const PrivateRoute = ({ authentication }: PrivateRouteProps) => {
+  // 인증을 했다면 하위 라우트로 이동, 안했다면 /로 이동
+  return authentication ? <Outlet /> : <Navigate to="/" />;
+};
+
+export default PrivateRoute;

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -1,22 +1,25 @@
 import { Route, Routes as ReactRoutes } from 'react-router-dom';
 import MainPage from '../pages/MainPage';
 import ResultPage from '../pages/ResultPage';
-import Test from '../pages/Test';
 import MyPage from '../pages/MyPage';
 import Interview from '../pages/Interview';
 import LoginPage from '../pages/LoginPage';
 import ReplyInterview from '../pages/ReplyInterview';
+import PrivateRoute from './PrivateRoute';
+import useUser from '../hooks/useUser';
 
 const Routes = () => {
+  const { user } = useUser();
   return (
     <ReactRoutes>
       <Route path="/" element={<MainPage />} />
-      <Route path="/test" element={<Test />} />
-      <Route path="/result" element={<ResultPage />} />
-      <Route path="/myPage" element={<MyPage />} />
-      <Route path="/interview" element={<Interview />} />
-      <Route path="/interview/:id" element={<ReplyInterview />} />
       <Route path="/login" element={<LoginPage />} />
+      <Route element={<PrivateRoute authentication={user ? true : false} />}>
+        <Route path="/result" element={<ResultPage />} />
+        <Route path="/myPage" element={<MyPage />} />
+        <Route path="/interview" element={<Interview />} />
+        <Route path="/interview/:id" element={<ReplyInterview />} />
+      </Route>
     </ReactRoutes>
   );
 };

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -7,6 +7,7 @@ import LoginPage from '../pages/LoginPage';
 import ReplyInterview from '../pages/ReplyInterview';
 import PrivateRoute from './PrivateRoute';
 import useUser from '../hooks/useUser';
+import NotFound from './NotFound';
 
 const Routes = () => {
   const { user } = useUser();
@@ -20,6 +21,7 @@ const Routes = () => {
         <Route path="/interview" element={<Interview />} />
         <Route path="/interview/:id" element={<ReplyInterview />} />
       </Route>
+      <Route path="*" element={<NotFound />} />
     </ReactRoutes>
   );
 };


### PR DESCRIPTION
1. PrivateRoute 컴포넌트를 제작하여 인증되지 않은 유저가 다른 페이지로 진입한다면 /로 리다이렉트 해줄 수 있도록 하였습니다.
(Outlet 컴포넌트 이용)
2. 준비된 페이지 이외에 라우터로 접근하게 된다면 /로 리다이렉트 해주게 변경하였습니다.
3. fix : login 페이지로 임의로 접근 시 /로 리다이렉트 되지 않는 현상이 발생하였습니다. 해당 페이지는 useUser를 사용하기 애매함으로 useEffect 구문에 navigate 함수 위치를 변경하였습니다.
4. App 의 useUser은 Route에서도 사용됨으로 제거하였습니다.